### PR TITLE
Support empty geometries

### DIFF
--- a/geobuf/decode.py
+++ b/geobuf/decode.py
@@ -121,6 +121,9 @@ class Decoder:
     def decode_line(self, coords, is_closed=False):
         obj = []
 
+        if not self.dim:
+            return obj
+
         r = range(self.dim)
         r2 = range(0, len(coords), self.dim)
         p0 = [0] * self.dim
@@ -136,34 +139,42 @@ class Decoder:
         return obj
 
     def decode_multi_line(self, geometry, is_closed=False):
-        if len(geometry.lengths) == 0:
-            return [self.decode_line(geometry.coords, is_closed=is_closed)]
-
         obj = []
-        i = 0
 
-        for l in geometry.lengths:
-            obj.append(self.decode_line(geometry.coords[i:i + l * self.dim], is_closed=is_closed))
-            i += l * self.dim
+        if len(geometry.coords) == 0:
+            return obj
+
+        if len(geometry.lengths) == 0:
+            obj = [self.decode_line(geometry.coords, is_closed=is_closed)]
+        else:
+            i = 0
+
+            for l in geometry.lengths:
+                obj.append(self.decode_line(geometry.coords[i:i + l * self.dim], is_closed=is_closed))
+                i += l * self.dim
 
         return obj
 
     def decode_multi_polygon(self, geometry):
-        if len(geometry.lengths) == 0:
-            return [[self.decode_line(geometry.coords, is_closed=True)]]
-
         obj = []
-        i = 0
-        j = 1
-        num_polygons = geometry.lengths[0]
 
-        for n in range(num_polygons):  # for every polygon
-            num_rings = geometry.lengths[j]
-            j += 1
-            rings = []
-            for l in geometry.lengths[j:j + num_rings]:
-                rings.append(self.decode_line(geometry.coords[i:i + l * self.dim], is_closed=True))
+        if len(geometry.coords) == 0:
+            return obj
+
+        if len(geometry.lengths) == 0:
+            obj = [[self.decode_line(geometry.coords, is_closed=True)]]
+        else:
+            i = 0
+            j = 1
+            num_polygons = geometry.lengths[0]
+
+            for n in range(num_polygons):  # for every polygon
+                num_rings = geometry.lengths[j]
                 j += 1
-                i += l * self.dim
-            obj.append(rings)
+                rings = []
+                for l in geometry.lengths[j:j + num_rings]:
+                    rings.append(self.decode_line(geometry.coords[i:i + l * self.dim], is_closed=True))
+                    j += 1
+                    i += l * self.dim
+                obj.append(rings)
         return obj

--- a/geobuf/decode.py
+++ b/geobuf/decode.py
@@ -142,9 +142,8 @@ class Decoder:
         obj = []
 
         if len(geometry.coords) == 0:
-            return obj
-
-        if len(geometry.lengths) == 0:
+            pass
+        elif len(geometry.lengths) == 0:
             obj = [self.decode_line(geometry.coords, is_closed=is_closed)]
         else:
             i = 0
@@ -159,9 +158,8 @@ class Decoder:
         obj = []
 
         if len(geometry.coords) == 0:
-            return obj
-
-        if len(geometry.lengths) == 0:
+            pass
+        elif len(geometry.lengths) == 0:
             obj = [[self.decode_line(geometry.coords, is_closed=True)]]
         else:
             i = 0

--- a/test/fixtures/empty-linestring.json
+++ b/test/fixtures/empty-linestring.json
@@ -1,0 +1,4 @@
+{
+  "type": "LineString",
+  "coordinates": []
+}

--- a/test/fixtures/empty-multilinestring.json
+++ b/test/fixtures/empty-multilinestring.json
@@ -1,0 +1,4 @@
+{
+  "type": "MultiLineString",
+  "coordinates": []
+}

--- a/test/fixtures/empty-multipoint.json
+++ b/test/fixtures/empty-multipoint.json
@@ -1,0 +1,4 @@
+{
+  "type": "MultiPoint",
+  "coordinates": []
+}

--- a/test/fixtures/empty-multipolygon.json
+++ b/test/fixtures/empty-multipolygon.json
@@ -1,0 +1,4 @@
+{
+  "type": "MultiPolygon",
+  "coordinates": []
+}

--- a/test/fixtures/empty-point.json
+++ b/test/fixtures/empty-point.json
@@ -1,0 +1,4 @@
+{
+  "type": "Point",
+  "coordinates": []
+}

--- a/test/fixtures/empty-polygon.json
+++ b/test/fixtures/empty-polygon.json
@@ -1,0 +1,4 @@
+{
+  "type": "Polygon",
+  "coordinates": []
+}

--- a/test/round_trip.py
+++ b/test/round_trip.py
@@ -8,8 +8,15 @@ import shutil
 exclude = {'precision.json'}
 files = glob.glob(os.path.join(os.path.dirname(__file__), "fixtures/*.json"))
 forward_fixtures = [filename for filename in files if os.path.basename(filename) not in exclude]
-# mixing properties and custom properties on features won't work without modifying the js library
-reverse_fixtures = [filename for filename in forward_fixtures if os.path.basename(filename) != 'props.json']
+
+# python encode -> javascript decode incompatibilities:
+#   - features containing both geojson properties and custom properties
+#   - empty geometries
+reverse_fixtures = [
+    filename for filename in forward_fixtures
+    if os.path.basename(filename) != 'props.json'
+    and not os.path.basename(filename).startswith('empty-')
+]
 
 
 def test_forward(filename):


### PR DESCRIPTION
Decoding certain types of empty geometries will either throw an exception or output a `coordinates` array that doesn't match the input e.g. `coordinates: [] -> coordinates: [[]]`